### PR TITLE
Use a hidden directory for vendored deps

### DIFF
--- a/install.go
+++ b/install.go
@@ -25,7 +25,7 @@ func has(c interface{}, key string) bool {
 
 func checkout(repo string, commit_or_branch_or_tag string, args []string) error {
 	installCmd := append([]string{"go", "install"}, args...)
-	vendor, err := filepath.Abs("vendor")
+	vendor, err := filepath.Abs(".gom")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Using a valid package name for putting dependencies in creates confusion in other tooling, is much nicer to put them somewhere at least hidden.
