### PR TITLE
Improve gom install for existing sources

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -42,10 +42,6 @@ Generate .travis.yml that uses `gom test`
 
     gom gen-travis-yml
 
-Use the network to update to update some packages
-
-    gom install -u
-
 Tutorial
 --------
 


### PR DESCRIPTION
`gom install -u` is not a good idea:
- it fails because go install doesn't accept the -u flag
- it forces to update all the repository
- it's more complicated for the users.

So, I've made a change in gom: it now uses the network to update the
repository if it can't find the correct commit/branch/tag.
