### PR TITLE
Fix parsing of groups with some groups enabled and some disabled.

### DIFF
--- a/gomfile.go
+++ b/gomfile.go
@@ -137,9 +137,11 @@ func parseGomfile(filename string) ([]Gom, error) {
 			skip++
 			continue
 		} else if re_end.MatchString(line) {
-			skip--
-			if !valid && skip < 0 {
-				return nil, fmt.Errorf("Syntax Error at line %d", n)
+			if !valid {
+				skip--
+				if skip < 0 {
+					return nil, fmt.Errorf("Syntax Error at line %d", n)
+				}
 			}
 			valid = false
 			continue

--- a/gomfile_test.go
+++ b/gomfile_test.go
@@ -80,3 +80,32 @@ gom 'github.com/mattn/go-gtk', :foobar => 'barbaz'
 		t.Fatalf("Expected %v, but %v:", expected, goms)
 	}
 }
+
+func TestGomfile4(t *testing.T) {
+	filename, err := tempGomfile(`
+group :development do
+	gom 'github.com/mattn/go-sqlite3', :tag => '3.14', :commit => 'asdfasdf'
+end
+
+group :test do
+	gom 'github.com/mattn/go-gtk', :foobar => 'barbaz'
+end
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	*developmentEnv = true
+	goms, err := parseGomfile(filename)
+	*developmentEnv = false
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []Gom{
+		{name: "github.com/mattn/go-sqlite3", options: map[string]interface{}{"tag": "3.14", "commit": "asdfasdf"}},
+	}
+	if !reflect.DeepEqual(goms, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, goms)
+	}
+}


### PR DESCRIPTION
Skip was incremented only if section is !valid, but decremented always. This
was leading to check skip < 0 and syntax error on valid gomfile.

Test included.
