### PR TITLE
Added "command" option example in the tutorial

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -73,6 +73,10 @@ If you want to bundle specified tag, branch or commit
     gom 'github.com/mattn/go-runewidth', :tag => 'tag_name'
     gom 'github.com/mattn/go-runewidth', :branch => 'branch_name'
     gom 'github.com/mattn/go-runewidth', :commit => 'commit_name'
+    
+If you want to bundle a repository that `go get` can't access
+
+    gom 'github.com/username/repository', :command => 'git clone http://example.com/repository.git'
 
 Todo
 ----


### PR DESCRIPTION
This adds an example for the "command" option implemented by #13 into the README so future users will not have to search in the sources or on the issue tracker.
