### PR TITLE
Hotfix: Add Gomfile dir to GOPATH

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -39,9 +39,9 @@ func ready() error {
 	for {
 		file := filepath.Join(dir, "Gomfile")
 		if isFile(file) {
-			vendor = dir +
+			vendor = filepath.Join(dir, vendorFolder) +
 				string(filepath.ListSeparator) +
-				filepath.Join(dir, vendorFolder)
+				dir
 			break
 		}
 		next := filepath.Clean(filepath.Join(dir, ".."))


### PR DESCRIPTION
Sorry. My first patch is invalid. gom install does not work. It's becouse invalid GOPATH elements order. Here is hotfix.
