### PR TITLE
Allow custom groups to be specified in the Gomfile.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -22,12 +22,21 @@ Gomfile
     gom 'github.com/mattn/go-scan', :commit => 'ecb144fb1f2848a24ebfdadf8e64380406d87206'
     gom 'github.com/daviddengcn/go-colortext'
     gom 'github.com/mattn/go-ole', :goos => 'windows'
+
+    # Execute only in the "test" environment.
     group :test do
         gom 'github.com/mattn/go-sqlite3'
     end
+
+    # Execute only for the "custom_group" group.
+    group :custom_group do
+        gom 'github.com/golang/lint/golint'
+    end
     
 By default `gom install` install all packages, except those in the listed groups.
-You can install packages from groups using flags (`development`, `test` & `production`) : `gom -test install`
+You can install packages from groups based on the environment using flags (`development`, `test` & `production`) : `gom -test install`
+
+Custom groups my be specified using the -groups flag : `gom -test -groups=custom_group,special install`
 
 Usage
 -----

--- a/gomfile.go
+++ b/gomfile.go
@@ -61,6 +61,13 @@ func matchEnv(any interface{}) bool {
 	case has(envs, "test") && *testEnv:
 		return true
 	}
+
+	for _, g := range customGroupList {
+		if has(envs, g) {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/gomfile_test.go
+++ b/gomfile_test.go
@@ -109,3 +109,45 @@ end
 		t.Fatalf("Expected %v, but %v:", expected, goms)
 	}
 }
+
+func TestGomfile5(t *testing.T) {
+	filename, err := tempGomfile(`
+group :custom_one do
+	gom 'github.com/mattn/go-sqlite3', :tag => '3.14', :commit => 'asdfasdf'
+end
+
+group :custom_two do
+	gom 'github.com/mattn/go-gtk', :foobar => 'barbaz'
+end
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	customGroupList = []string{"custom_one", "custom_two"}
+	goms, err := parseGomfile(filename)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []Gom{
+		{name: "github.com/mattn/go-sqlite3", options: map[string]interface{}{"tag": "3.14", "commit": "asdfasdf"}},
+		{name: "github.com/mattn/go-gtk", options: map[string]interface{}{"foobar": "barbaz"}},
+	}
+	if !reflect.DeepEqual(goms, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, goms)
+	}
+
+	customGroupList = []string{"custom_one"}
+	goms, err = parseGomfile(filename)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = []Gom{
+		{name: "github.com/mattn/go-sqlite3", options: map[string]interface{}{"tag": "3.14", "commit": "asdfasdf"}},
+	}
+	if !reflect.DeepEqual(goms, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, goms)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 )
 
 func usage() {
@@ -28,6 +29,8 @@ func usage() {
 var productionEnv = flag.Bool("production", false, "production environment")
 var developmentEnv = flag.Bool("development", false, "development environment")
 var testEnv = flag.Bool("test", false, "test environment")
+var customGroups = flag.String("groups", "", "comma-separated list of Gomfile groups")
+var customGroupList []string
 var vendorFolder string
 
 func main() {
@@ -41,6 +44,8 @@ func main() {
 	if !*productionEnv && !*developmentEnv && !*testEnv {
 		*developmentEnv = true
 	}
+
+	customGroupList = strings.Split(*customGroups, ",")
 
 	if len(os.Getenv("GOM_VENDOR_NAME")) > 0 {
 		vendorFolder = os.Getenv("GOM_VENDOR_NAME")


### PR DESCRIPTION
Greetings! I have a use case that would require using various groups in my Gomfile. The logic for environments and groups is very similar, but I need more than three options. For example, depending on os/go versions, Travis builds seem to fail if we try to fetch tools from the new urls (golang.org/x), but we don't want to overload "test" and "development" to specify these build differences.

This PR suggests a solution using custom group names in addition to the three environments. This would allow many new combinations of Goms by specifying one or more groups in the install command. e.g.

```
$ gom install -test -groups=test_golang_org
```

```ruby
# fetches from golang.org
group :test_golang_org do
  gom 'golang.org/x/tools/cmd/vet'
  gom 'golang.org/x/tools/cmd/cover'
end

# fetches from code.google.com
group :test_google_com do
  gom 'code.google.com/p/go.tools/cmd/vet'
  gom 'code.google.com/p/go.tools/cmd/cover'
end

group :test do
  gom 'gopkg.in/check.v1'
  gom 'github.com/golang/lint/golint'
  gom 'github.com/onsi/ginkgo/ginkgo'
  gom 'github.com/onsi/gomega'
end
```

Please let me know what you think. Thanks!