### PR TITLE
Set GOBIN for `gom install`

### DIFF
--- a/install.go
+++ b/install.go
@@ -256,6 +256,10 @@ func install(args []string) error {
 	if err != nil {
 		return err
 	}
+	err = os.Setenv("GOBIN", filepath.Join(vendor, "bin"))
+	if err != nil {
+		return err
+	}
 
 	// 1. Filter goms to install
 	goms := make([]Gom, 0)


### PR DESCRIPTION
If you set `$GOBIN` in your shell (like I did), you still want gom to install binaries to the `_vendor/bin` folder.  So you need to set `$GOBIN` for `gom install` command, and that's exactly what this PR does.