### PR TITLE
Add commands: `vet`, `list`, `env`

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,10 @@ func usage() {
    gom doc     [options]   : Run godoc for bundles
    gom exec    [arguments] : Execute command with bundle environment
    gom tool    [options]   : Run go tool with bundles
+   gom env     [arguments] : Run go env
    gom fmt     [arguments] : Run go fmt
+   gom list    [arguments] : Run go list
+   gom vet     [arguments] : Run go vet
    gom gen travis-yml      : Generate .travis.yml which uses "gom test"
    gom gen gomfile         : Scan packages from current directory as root
                               recursively, and generate Gomfile
@@ -69,10 +72,8 @@ func main() {
 		err = run(append([]string{"godoc"}, subArgs...), None)
 	case "exec", "e":
 		err = run(subArgs, None)
-	case "tool":
-		err = run(append([]string{"go", "tool"}, subArgs...), None)
-	case "fmt":
-		err = run(append([]string{"go", "fmt"}, subArgs...), None)
+	case "env", "tool", "fmt", "list", "vet":
+		err = run(append([]string{"go", flag.Arg(0)}, subArgs...), None)
 	case "gen", "g":
 		switch flag.Arg(1) {
 		case "travis-yml":


### PR DESCRIPTION
Some tools (eg `gorename`) are relying on go commands like `go env` to get environment variables.
If one wants to fully take advantage of `gom` he should be able to use this tools in editor. Emacs function `go-root-and-paths` uses go-command variable to call go tool and passes `env` as a first parameter.

To fully substitute `go` tool one would need to support that additional subcommands.