### PR TITLE
Vim plugin to set GOPATH.

### DIFF
--- a/misc/vim/plugin/gom.vim
+++ b/misc/vim/plugin/gom.vim
@@ -1,0 +1,14 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+function! s:setGomEnv()
+  let $GOPATH = filter(split(system("gom exec env"), "\n"), "v:val =~ '^GOPATH='")[0][7:]
+endfunction
+
+
+command! SetGomEnv call s:setGomEnv()
+
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
It would be a help some VimPlugin like a Gocode to find the modules managed by Gom.

Gomで管理してるプラグインをgocodeの補完候補に出すための関数です。Gitしか考慮されていませんが……
:pray: 