### PR TITLE
add option for skip dep, go get -insecure, and change local repos location

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -100,6 +100,10 @@ If you want to bundle a repository that `go get` can't access
 
     gom 'github.com/username/repository', :command => 'git clone http://example.com/repository.git'
 
+If you want to change local repository directory with commend 'git clone', also skipdep and insecure, which is useful in internal network environment.
+
+    gom 'github.com/username/repository', :private => 'ture', :target => 'repository', insecure=>'true', skipdep=>'true' 
+
 Todo
 ----
 


### PR DESCRIPTION
1. add option when go get -insecure

2. finish support for different local location, which is common in history system.

3. add skipdep option to disable some repo which is fetched use 'git clone' which it doesn't support go get -d, while we can add dependency gom  manually.

4. fix bug 'git pull origin'  when you are not currently on a branch.