### PR TITLE
enhance support for option private, which support vcs commend.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -100,6 +100,10 @@ If you want to bundle a repository that `go get` can't access
 
     gom 'github.com/username/repository', :command => 'git clone http://example.com/repository.git'
 
+If you want to change local repository directory with commend 'git clone', also skipdep and insecure, which is useful in internal network environment.
+
+    gom 'github.com/username/repository', :private => 'ture', :target => 'repository', insecure=>'true', skipdep=>'true' 
+
 Todo
 ----
 


### PR DESCRIPTION
1. Enhance support for option private. 
   It may call vcs commend, change local src location.

2. Add option insecure.
   Update in insecure environment. go get -insecure some.host.org/name/repo

3. Add option skipdep
   At the same time, there are some scene that local repo can't run go get -d to solve dependency. You can add dep in Gomfile manually.

4. Fix bug
   Commed 'git pull origin' may cause error when you are not currently on a branch. I change it to 'git pull origin master'

Example:

    gom 'code.exp.org/name/repo', :target=>'repo', :private=>'true', :insecure=>'true', :skipdep=>'true', :commit=>'a501adcb'

It will run 'git clone code.exp.org/name/repo' to _vender/src/repo, and it will turn local commit to 'a501adcb'. It will not solve dependency automatic, you must add dep in Gomfile manually.