### PR TITLE
Flag to install dependent packages non recursively 

### DIFF
--- a/install.go
+++ b/install.go
@@ -119,7 +119,13 @@ func (gom *Gom) Update() error {
 			cmdArgs = append(cmdArgs, "-insecure")
 		}
 	}
-	cmdArgs = append(cmdArgs, gom.name+"/...")
+	recursive := "/..."
+	if recursiveFlag, ok := gom.options["recursive"].(string); ok {
+		if recursiveFlag == "false" {
+			recursive = ""
+		}
+	}
+	cmdArgs = append(cmdArgs, gom.name+recursive)
 
 	fmt.Printf("updating %s\n", gom.name)
 	return run(cmdArgs, Green)
@@ -182,8 +188,14 @@ func (gom *Gom) Clone(args []string) error {
 			cmdArgs = append(cmdArgs, "-insecure")
 		}
 	}
+	recursive := "/..."
+	if recursiveFlag, ok := gom.options["recursive"].(string); ok {
+		if recursiveFlag == "false" {
+			recursive = ""
+		}
+	}
 	cmdArgs = append(cmdArgs, args...)
-	cmdArgs = append(cmdArgs, gom.name+"/...")
+	cmdArgs = append(cmdArgs, gom.name+recursive)
 
 	fmt.Printf("downloading %s\n", gom.name)
 	return run(cmdArgs, Blue)


### PR DESCRIPTION
Changes made in f4cb457f0d620b7c062d0b48fc08ca901f274560 is breaking the Gom install in one of our codebases, as it tries to fetch the packages recursively(`go get` with a `./...`) and tries to compile them, which isn't required.   

As a solution, added a flag, to optionally not fetch the packages  The default is true.

Usage 
```
gom 'github.com/tinygrasshopper/rubex', :recursive => 'false'
gom 'github.com/tinygrasshopper/bettercsv'
```
Results in:
```
go get -d github.com/tinygrasshopper/rubex
go get -d github.com/tinygrasshopper/bettercsv/...
```
