### PR TITLE
Adds support of Go 1.6+ and 1.7+.

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,4 +1,5 @@
 group :production, :development do
-  gom 'github.com/daviddengcn/go-colortext', :goos => [:windows, :linux, :darwin]
+  gom 'github.com/mattn/gover'
   gom 'github.com/hashicorp/go-version'
+  gom 'github.com/daviddengcn/go-colortext', :goos => [:windows, :linux, :darwin]
 end

--- a/Gomfile
+++ b/Gomfile
@@ -1,3 +1,4 @@
 group :production, :development do
   gom 'github.com/daviddengcn/go-colortext', :goos => [:windows, :linux, :darwin]
+  gom 'github.com/hashicorp/go-version'
 end

--- a/install.go
+++ b/install.go
@@ -519,7 +519,7 @@ func install(args []string) error {
 		goms = append(goms, gom)
 	}
 
-	if isVendoringSupported() {
+	if isVendoringSupported {
 		err = moveSrcToVendorSrc(vendor)
 		if err != nil {
 			return err
@@ -555,7 +555,7 @@ func install(args []string) error {
 		}
 	}
 
-	if isVendoringSupported() {
+	if isVendoringSupported {
 		err = moveSrcToVendor(vendor)
 		if err != nil {
 			return err
@@ -583,7 +583,7 @@ func update() error {
 		return err
 	}
 
-	if isVendoringSupported() {
+	if isVendoringSupported {
 		err = moveSrcToVendorSrc(vendor)
 		if err != nil {
 			return err
@@ -604,7 +604,7 @@ func update() error {
 		}
 	}
 
-	if isVendoringSupported() {
+	if isVendoringSupported {
 		err = moveSrcToVendor(vendor)
 		if err != nil {
 			return err

--- a/install.go
+++ b/install.go
@@ -519,7 +519,7 @@ func install(args []string) error {
 		goms = append(goms, gom)
 	}
 
-	if go15VendorExperimentEnv {
+	if isVendoringSupported() {
 		err = moveSrcToVendorSrc(vendor)
 		if err != nil {
 			return err
@@ -555,7 +555,7 @@ func install(args []string) error {
 		}
 	}
 
-	if go15VendorExperimentEnv {
+	if isVendoringSupported() {
 		err = moveSrcToVendor(vendor)
 		if err != nil {
 			return err
@@ -583,7 +583,7 @@ func update() error {
 		return err
 	}
 
-	if go15VendorExperimentEnv {
+	if isVendoringSupported() {
 		err = moveSrcToVendorSrc(vendor)
 		if err != nil {
 			return err
@@ -604,7 +604,7 @@ func update() error {
 		}
 	}
 
-	if go15VendorExperimentEnv {
+	if isVendoringSupported() {
 		err = moveSrcToVendor(vendor)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/hashicorp/go-version"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -38,11 +40,9 @@ var testEnv = flag.Bool("test", false, "test environment")
 var customGroups = flag.String("groups", "", "comma-separated list of Gomfile groups")
 var customGroupList []string
 var vendorFolder string
-var go15VendorExperimentEnv bool
 
 func init() {
-	go15VendorExperimentEnv = len(os.Getenv("GO15VENDOREXPERIMENT")) > 0
-	if go15VendorExperimentEnv {
+	if isVendoringSupported() {
 		vendorFolder = "vendor"
 	} else {
 		if len(os.Getenv("GOM_VENDOR_NAME")) > 0 {
@@ -53,8 +53,30 @@ func init() {
 	}
 }
 
+func isVendoringSupported() bool {
+	go15, _ := version.NewVersion("1.5.0")
+	go16, _ := version.NewVersion("1.6.0")
+	go17, _ := version.NewVersion("1.7.0")
+
+	goVer, err := version.NewVersion(strings.TrimPrefix(runtime.Version(), "go"))
+	if err != nil {
+		panic(fmt.Sprintf("runtime.Version() returned invalid semantic version: %s", runtime.Version()))
+	}
+
+	// See: https://golang.org/doc/go1.6#go_command
+	if goVer.LessThan(go15) {
+		return false
+	} else if (goVer.Equal(go15) || goVer.GreaterThan(go15)) && goVer.LessThan(go16) {
+		return os.Getenv("GO15VENDOREXPERIMENT") == "1"
+	} else if (goVer.Equal(go16) || goVer.GreaterThan(go16)) && goVer.LessThan(go17) {
+		return os.Getenv("GO15VENDOREXPERIMENT") != "0"
+	} else {
+		return true
+	}
+}
+
 func vendorSrc(vendor string) string {
-	if go15VendorExperimentEnv {
+	if isVendoringSupported() {
 		return vendor
 	} else {
 		return filepath.Join(vendor, "src")

--- a/main.go
+++ b/main.go
@@ -40,9 +40,11 @@ var testEnv = flag.Bool("test", false, "test environment")
 var customGroups = flag.String("groups", "", "comma-separated list of Gomfile groups")
 var customGroupList []string
 var vendorFolder string
+var isVendoringSupported bool
 
 func init() {
-	if isVendoringSupported() {
+	isVendoringSupported = checkVendoringSupport()
+	if isVendoringSupported {
 		vendorFolder = "vendor"
 	} else {
 		if len(os.Getenv("GOM_VENDOR_NAME")) > 0 {
@@ -53,7 +55,7 @@ func init() {
 	}
 }
 
-func isVendoringSupported() bool {
+func checkVendoringSupport() bool {
 	go15, _ := version.NewVersion("1.5.0")
 	go16, _ := version.NewVersion("1.6.0")
 	go17, _ := version.NewVersion("1.7.0")
@@ -76,7 +78,7 @@ func isVendoringSupported() bool {
 }
 
 func vendorSrc(vendor string) string {
-	if isVendoringSupported() {
+	if isVendoringSupported {
 		return vendor
 	} else {
 		return filepath.Join(vendor, "src")

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"github.com/hashicorp/go-version"
+	"github.com/mattn/gover"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -60,9 +60,9 @@ func checkVendoringSupport() bool {
 	go16, _ := version.NewVersion("1.6.0")
 	go17, _ := version.NewVersion("1.7.0")
 
-	goVer, err := version.NewVersion(strings.TrimPrefix(runtime.Version(), "go"))
+	goVer, err := version.NewVersion(strings.TrimPrefix(gover.Version(), "go"))
 	if err != nil {
-		panic(fmt.Sprintf("runtime.Version() returned invalid semantic version: %s", runtime.Version()))
+		panic(fmt.Sprintf("gover.Version() returned invalid semantic version: %s", gover.Version()))
 	}
 
 	// See: https://golang.org/doc/go1.6#go_command


### PR DESCRIPTION
@mattn 
Go 1.6 supports vendoring by default, so `GO15VENDOREXPERIMENT` env should not be required to use `vendor/` directory.

Previously, gom uses `_vendor/` directory even with Go version is 1.6+.
See: http://akirachiku.com/2016/03/01/go16-development.html#vendoring (Japanese)

gom should use `vendor/` directory with Go 1.6+ by default.
But when `GO15VENDOREXPERIMENT=0` is explicitly set with Go `<= 1.6 && >1.7` , gom should use `_vendor/` (or `GOM_VENDOR_NAME` when it's set) because vendoring is not supported by Go itself.

Quote from https://golang.org/doc/go1.6#go_command :

>
Go 1.5 introduced experimental support for vendoring, enabled by setting the GO15VENDOREXPERIMENT environment variable to 1. Go 1.6 keeps the vendoring support, no longer considered experimental, and enables it by default. It can be disabled explicitly by setting the GO15VENDOREXPERIMENT environment variable to 0. Go 1.7 will remove support for the environment variable.