### PR TITLE
fix bug with local package in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gom
 _vendor/**
+.idea

--- a/gen.go
+++ b/gen.go
@@ -34,11 +34,6 @@ script:
 	return nil
 }
 
-// http://code.google.com/p/go/source/browse/src/cmd/go/pkg.go?name=go1.1.2#96
-func isStandardImport(path string) bool {
-	return !strings.Contains(path, ".")
-}
-
 func appendPkg(pkgs []string, pkg string) []string {
 	for _, ele := range pkgs {
 		if ele == pkg {
@@ -60,10 +55,9 @@ func scanDirectory(path, srcDir string) (ret []string, err error) {
 	if err != nil {
 		return ret, err
 	}
-
 	for _, imp := range pkg.Imports {
 		switch {
-		case isStandardImport(imp):
+		case pkg.Goroot:
 			// Ignore standard packages
 		case !build.IsLocalImport(imp):
 			// Add the external package


### PR DESCRIPTION
fix for https://github.com/mattn/gom/issues/65

testin on beego
tree beego
-conf
---app.conf
-controllers
---default.go
-models
-routers
---router.go
-static
---css
---img
---js
-tests
---default_test.go
-views
---index.tpl
-Gomfile
-main.go

in default.go we have  external import github.com/k0kubun/pp
before fix 
```
gom 'github.com/astaxie/beego', :commit => '88816348b92863cc17109721e39e069c3209c206'
```
after fix 
```
gom 'github.com/astaxie/beego', :commit => '88816348b92863cc17109721e39e069c3209c206'
gom 'github.com/k0kubun/pp', :commit => '36d5366f4ec038f9a76dd85c7b29074089bb9b9e'
gom 'github.com/mattn/go-colorable', :commit => '9cbef7c35391cca05f15f8181dc0b18bc9736dbb'
```
I think we need  add  imports from *_test.go files? @mattn 