### PR TITLE
Fix moving 'vendor/src' path when gom install with go1.7

### DIFF
--- a/install.go
+++ b/install.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-version"
+	"github.com/mattn/gover"
 	"os"
 	"os/exec"
 	"path"
@@ -555,7 +557,7 @@ func install(args []string) error {
 		}
 	}
 
-	if isVendoringSupported {
+	if isMoveSrc() {
 		err = moveSrcToVendor(vendor)
 		if err != nil {
 			return err
@@ -604,7 +606,7 @@ func update() error {
 		}
 	}
 
-	if isVendoringSupported {
+	if isMoveSrc() {
 		err = moveSrcToVendor(vendor)
 		if err != nil {
 			return err
@@ -612,4 +614,17 @@ func update() error {
 	}
 
 	return writeGomfile("Gomfile", goms)
+}
+
+func isMoveSrc() bool {
+	go17, _ := version.NewVersion("1.7.0")
+
+	goVer, err := version.NewVersion(strings.TrimPrefix(gover.Version(), "go"))
+	if err != nil {
+		panic(fmt.Sprintf("gover.Version() returned invalid semantic version: %s", gover.Version()))
+	}
+	if goVer.Equal(go17) || goVer.GreaterThan(go17) {
+		return false
+	}
+	return isVendoringSupported
 }


### PR DESCRIPTION
In go1.7, I can't work fine.

For example:
```
main.go:7:2: cannot find package "github.com/google/go-github/github" in any of:
	/Users/akira/.gvm/gos/go1.7.1/src/github.com/google/go-github/github (from $GOROOT)
	/Users/akira/github.com/create-pull-request/vendor/src/github.com/google/go-github/github (from $GOPATH)
	/Users/akira/github.com/create-pull-request/src/github.com/google/go-github/github
	/Users/akira/.gvm/pkgsets/go1.7.1/global/src/github.com/google/go-github/github
main.go:8:2: cannot find package "golang.org/x/oauth2" in any of:
	/Users/akira/.gvm/gos/go1.7.1/src/golang.org/x/oauth2 (from $GOROOT)
	/Users/akira/github.com/create-pull-request/vendor/src/golang.org/x/oauth2 (from $GOPATH)
	/Users/akira/github.com/create-pull-request/src/golang.org/x/oauth2
	/Users/akira/.gvm/pkgsets/go1.7.1/global/src/golang.org/x/oauth2
gom:  exit status 1
```

日本語でも書いときます。
Go1.7で`gom install` すると、 `vendor/src` 以下にソース取得してビルドした後、`vendor/src`の中身を`vendor/`に移動していました。
これがGo1.7で読めなくなっており（Go1.7では `vendor/src`を読みに行く）、その修正になります。