### PR TITLE
Fix test if TMPDIR is a symbolic link

### DIFF
--- a/gen_test.go
+++ b/gen_test.go
@@ -14,6 +14,13 @@ func TestGomfile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
+
+	// 'go env GOPATH' returns followed links while ioutil.TempDir(os.TempDir) may returns symbolic link
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Tests are failed if environment variable TMPDIR points to symbolic link.
Because 'go env GOPATH' returns followed links. TMPDIR is used by
os.TempDir and os.TempDir is used by ioutil.TempDir.

For example TMPDIR value on macOS points to a symbolic link by default. Its value is
'/var/folders/...' and '/var' is a symbolic link of '/private/var'. So temporary
directory path is '/var/folders/...' while 'go env GOPATH' returns
'/private/var/...', they never matches each other.